### PR TITLE
Remove coupler warnings

### DIFF
--- a/simple_coupler/coupler_main.F90
+++ b/simple_coupler/coupler_main.F90
@@ -470,7 +470,7 @@ if (restart_days > 0 .or. restart_secs > 0) intrm_rst = .true.
 !----- write restart file ------
     call mpp_set_current_pelist()
     if (mpp_pe() == mpp_root_pe())then
-    call mpp_open( unit, 'RESTART/coupler.res', nohdrs=.TRUE. )
+        call mpp_open( unit, 'RESTART/coupler.res', nohdrs=.TRUE. )
         write( unit, '(i6,8x,a)' )calendar_type, &
              '(Calendar: no_calendar=0, thirty_day_months=1, julian=2, gregorian=3, noleap=4)'
 
@@ -478,7 +478,7 @@ if (restart_days > 0 .or. restart_secs > 0) intrm_rst = .true.
              'Model start time:   year, month, day, hour, minute, second'
         write( unit, '(6i6,8x,a)' )date, &
              'Current model time: year, month, day, hour, minute, second'
-    call mpp_close(unit)
+        call mpp_close(unit)
     endif
 
 !----- final output of diagnostic fields ----

--- a/simple_coupler/coupler_main.F90
+++ b/simple_coupler/coupler_main.F90
@@ -434,7 +434,7 @@ if (restart_days > 0 .or. restart_secs > 0) intrm_rst = .true.
                                  date(4), date(5), date(6))
 
 !----- write restart file ------
-
+    call mpp_set_current_pelist()
     if (mpp_pe() == mpp_root_pe())then
         call mpp_open( unit, 'RESTART/'//trim(timestamp)//'.coupler.res', nohdrs=.TRUE. )
         write( unit, '(i6,8x,a)' )calendar_type, &
@@ -468,9 +468,9 @@ if (restart_days > 0 .or. restart_secs > 0) intrm_rst = .true.
               'final time does not match expected ending time', WARNING)
 
 !----- write restart file ------
-
-    call mpp_open( unit, 'RESTART/coupler.res', nohdrs=.TRUE. )
+    call mpp_set_current_pelist()
     if (mpp_pe() == mpp_root_pe())then
+    call mpp_open( unit, 'RESTART/coupler.res', nohdrs=.TRUE. )
         write( unit, '(i6,8x,a)' )calendar_type, &
              '(Calendar: no_calendar=0, thirty_day_months=1, julian=2, gregorian=3, noleap=4)'
 
@@ -478,8 +478,8 @@ if (restart_days > 0 .or. restart_secs > 0) intrm_rst = .true.
              'Model start time:   year, month, day, hour, minute, second'
         write( unit, '(6i6,8x,a)' )date, &
              'Current model time: year, month, day, hour, minute, second'
-    endif
     call mpp_close(unit)
+    endif
 
 !----- final output of diagnostic fields ----
 


### PR DESCRIPTION
Implementing changes that Joseph Mouallem has made.  Changes were tested by Joseph and Rusty.

This will fix warnings when writing coupler.res which should be only written by one PE.