### PR TITLE
FMS 2021.02 input_nml_file update

### DIFF
--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -80,8 +80,8 @@ module GFS_typedefs
     character(len=32), pointer :: tracer_names(:) !< tracers names to dereference tracer id
                                                   !< based on name location in array
     character(len=65) :: fn_nml                   !< namelist filename
-    character(len=256), pointer :: input_nml_file(:) !< character string containing full namelist
-                                                   !< for use with internal file reads
+    character(len=:), pointer, dimension(:) :: input_nml_file => null() !< character string containing full namelist
+                                                                        !< for use with internal file reads
   end type GFS_init_type
 
 
@@ -360,8 +360,8 @@ module GFS_typedefs
     integer              :: master          !< MPI rank of master atmosphere processor
     integer              :: nlunit          !< unit for namelist
     character(len=64)    :: fn_nml          !< namelist filename for surface data cycling
-    character(len=256), pointer :: input_nml_file(:) !< character string containing full namelist
-                                                   !< for use with internal file reads
+    character(len=:), pointer, dimension(:) :: input_nml_file => null() !< character string containing full namelist
+                                                                        !< for use with internal file reads
     real(kind=kind_phys) :: fhzero          !< seconds between clearing of diagnostic buckets
     logical              :: ldiag3d         !< flag for 3d diagnostic fields
     logical              :: lssav           !< logical flag for storing diagnostics
@@ -1483,7 +1483,7 @@ module GFS_typedefs
     integer,                intent(in) :: idat(8)
     integer,                intent(in) :: jdat(8)
     character(len=32),      intent(in) :: tracer_names(:)
-    character(len=*),       intent(in), pointer :: input_nml_file(:)
+    character(len=:),       intent(in),  dimension(:), pointer :: input_nml_file
     !--- local variables
     integer :: n
     integer :: ios
@@ -1801,6 +1801,7 @@ module GFS_typedefs
 
     !--- read in the namelist
 #ifdef INTERNAL_FILE_NML
+    allocate(Model%input_nml_file, mold=input_nml_file)
     Model%input_nml_file => input_nml_file
     read(Model%input_nml_file, nml=gfs_physics_nml)
 #else

--- a/atmos_drivers/coupled/atmos_model.F90
+++ b/atmos_drivers/coupled/atmos_model.F90
@@ -406,6 +406,7 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step)
    Init_parm%tracer_names    => tracer_names
 
 #ifdef INTERNAL_FILE_NML
+   allocate(Init_parm%input_nml_file, mold=input_nml_file)
    Init_parm%input_nml_file  => input_nml_file
    Init_parm%fn_nml='using internal file'
 #else


### PR DESCRIPTION
A change to FMS 2021.02 requires an update to the way input_nml_file is declared in GFS_typedef.

This change has been tested with both GNU 10.2.0 and Intel 18.0.6.288 and the SHiELD model.

This change will work with the currently released FMS 2021.01 and does not cause answer changes.