### PR TITLE
FMS2 io updates

### DIFF
--- a/FV3GFS/FV3GFS_io.F90
+++ b/FV3GFS/FV3GFS_io.F90
@@ -17,7 +17,7 @@ module FV3GFS_io_mod
   use block_control_mod,  only: block_control_type
   use mpp_mod,            only: mpp_error, mpp_pe, mpp_root_pe, &
                                 mpp_chksum, NOTE, FATAL, mpp_get_current_pelist_name
-  use fms_mod,            only: file_exist, stdout
+  use fms_mod,            only: file_exist, stdout, set_domain
   use fms_io_mod,         only: restart_file_type, free_restart_type, &
                                 register_restart_field,               &
                                 restore_state, save_restart
@@ -119,7 +119,9 @@ module FV3GFS_io_mod
     type(block_control_type), intent(in)    :: Atm_block
     type(IPD_control_type),   intent(in)    :: Model
     type(domain2d),           intent(in)    :: fv_domain
- 
+
+    call set_domain(fv_domain)
+
     !--- read in surface data from chgres 
     call sfc_prop_restart_read (IPD_Data%Sfcprop, Atm_block, Model, fv_domain)
  


### PR DESCRIPTION
**Description**

This pull request implements fms2io into the SHiELD_driver code. In a coming release of FMS, the modules mpp_io_mod and fms_io_mod are being deprecated and replaced by the new fms2_io_mod.   These changes go hand in hand with the changes to the dycore in [PR74](https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/74)
Fixes # (issue)

**How Has This Been Tested?**

These changes have been tested with SHiELD and do not change answers. Using FMS [2021.02-beta2 tag](https://github.com/NOAA-GFDL/FMS/releases/tag/2021.02-beta2) and GFDL_atmos_cubed_sphere [laurenchilutti:fms2_io_implementation](https://github.com/laurenchilutti/GFDL_atmos_cubed_sphere/tree/fms2_io_implementation)
Tests run are:

C48 grid test with coarse grained restarts and intermediate restarts and with external_ic=true and nggps_ic=true (No nests)
C48 grid test with coarse grained restarts and intermediate restarts and warm start from RESTARTS (No nests)
C48 grid test with external_ic=true and nggps_ic=true (No nests)
C48 grid test with external_ic=true and nggps_ic=true and warm start from RESTARTS (No nests)
C48 grid test with external_ic=true and nggps_ic=true and 1 nested grid
C768 grid test with external_ic=true and nggps_ic=true (No nests)
C768 grid test with external_ic=true and nggps_ic=true and 1 nested grid
Regional 3km test with external_ic=true and nggps_ic=true (No nests)
